### PR TITLE
Deprecate and remove dashboard code

### DIFF
--- a/backend/app/controllers/spree/admin/dashboards_controller.rb
+++ b/backend/app/controllers/spree/admin/dashboards_controller.rb
@@ -3,6 +3,10 @@
 module Spree
   module Admin
     class DashboardsController < BaseController
+      before_action :deprecate
+      def deprecate
+        Spree.deprecator.warn "The #{self.class.name} is deprecated. If you still use dashboards, please copy all controllers and views from solidus_backend to your application."
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/dashboards/home.html.erb
+++ b/backend/app/views/spree/admin/dashboards/home.html.erb
@@ -1,1 +1,2 @@
 <%# Placeholder view for a home dashboard %>
+<p><%= Spree.deprecator.warn "The Home view is deprecated, If you still use dashboards, please copy all controllers and views from solidus_backend to your application." %></p>

--- a/backend/spec/controllers/spree/admin/dashboards_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/dashboards_controller_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Admin::DashboardsController, type: :controller do
+    it 'displays a warning' do
+      expect(Spree.deprecator).to receive(:deprecate)
+    end
+end

--- a/backend/spec/views/spree/admin/shared/home_spec.rb
+++ b/backend/spec/views/spree/admin/shared/home_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'spree/admin/dashboards/home', type: :view, partial_double_verification: false do
+  it 'renders the home view' do
+    render
+
+    expect(rendered).to match /The Home view is deprecated/
+  end
+end

--- a/core/lib/spree/permission_sets/dashboard_display.rb
+++ b/core/lib/spree/permission_sets/dashboard_display.rb
@@ -9,6 +9,8 @@ module Spree
     # customizations.
     class DashboardDisplay < PermissionSets::Base
       def activate!
+          Spree.deprecator.warn "The #{self.class.name} module is deprecated. " \
+            "If you still use dashboards, please copy all controllers and views from #{self.class.name} to your application."
           can [:admin, :home], :dashboards
       end
     end

--- a/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/dashboard_display_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
 
   context "when activated" do
     before do
+      Spree.Deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
       described_class.new(ability).activate!
     end
 
@@ -17,6 +18,7 @@ RSpec.describe Spree::PermissionSets::DashboardDisplay do
   end
 
   context "when not activated" do
+    Spree.Deprecator.warn 'The dashboard_display_spec.rb test is being deprecated.  Please update your source code.'
     it { is_expected.not_to be_able_to(:admin, :dashboards) }
     it { is_expected.not_to be_able_to(:home, :dashboards) }
   end


### PR DESCRIPTION
As stated by @jarednorman (in #4860):
> None of this provides any real value. Adding a custom dashboard is
> trivial and I really don't think we need a custom permission set and
> empty controller/view.